### PR TITLE
Fix after renaming master to main

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -7,7 +7,7 @@ from ._version import __version__
 
 POOCH = pooch.create(
     path=pooch.os_cache('geocat'),
-    base_url='https://github.com/NCAR/GeoCAT-datafiles/raw/master/',
+    base_url='https://github.com/NCAR/GeoCAT-datafiles/raw/main/',
     registry={'registry.txt': None})
 
 def _update_registry(p):


### PR DESCRIPTION
This PR fixes the broken `_inint.py` after `master` to `main` branch renaming. Since this broken thing will result in errors where `geocat-datafiles` is used (e.g. `GeoCAT-examples`), a newer version of `geocat-datafiles` should be generated and uploaded to Anaconda channel after this PR is merged.