### PR TITLE
Update citation texts per Zenodo DOI implementation per-version

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,7 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - given-names: "Visualization & Analysis Systems Technologies"
+title: "Geoscience Community Analysis Toolkit: GeoCAT-datafiles"
+doi: 10.5281/zenodo.6684782
+url: "https://github.com/NCAR/geocat-datafiles"

--- a/CITATION.md
+++ b/CITATION.md
@@ -1,0 +1,39 @@
+
+# How to cite GeoCAT-datafiles
+
+If you use this software, please cite it as described below:
+
+Each GeoCAT-datafiles version is assigned a separate Digital Object Identifier (DOI) to allow
+users to access older releases. This ensures that users are not only able to cite the specific
+software version through DOIs but are also able to download & use the corresponding release for
+reproducibility purposes.
+
+If you would like to cite GeoCAT-datafiles as a whole (without referring to a specific version), use
+the following text:
+
+**Visualization & Analysis Systems Technologies. (2020).
+Geoscience Community Analysis Toolkit: GeoCAT-datafiles [Software].
+Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6684782.**
+
+Instead, if you would like to cite a specific version of GeoCAT-datafiles, use the following text:
+
+**Visualization & Analysis Systems Technologies. (\<Year\>).
+Geoscience Community Analysis Toolkit: GeoCAT-datafiles (v\<version\>) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:\<DOI\>.**
+
+In the above citation text, update the year, GeoCAT-datafiles version, and DOI as appropriate. For
+example:
+
+**Visualization & Analysis Systems Technologies. (2022).
+Geoscience Community Analysis Toolkit: GeoCAT-datafiles (v2022.03.0) [Software].
+Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6684830.**
+
+Please find DOIs for all the GeoCAT-datafiles versions [here](
+https://zenodo.org/search?page=1&size=20&q=conceptrecid:%226684782%22&sort=-version&all_versions=True).
+
+Please note: The DOI minting service, Zenodo, might be suggesting their own citation text (as
+they are the publisher of such DOIs) in their website. We prefer the text we recommend here to be used;
+however, either way is acceptable.
+
+For further information, please refer to
+[GeoCAT homepage - Citation](https://geocat.ucar.edu/pages/citation.html).

--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ downloading from the GeoCAT-datafiles repository, if not in the local storage, w
 
 Please see our documentation for 
 [installation instructions](https://github.com/NCAR/geocat-datafiles/blob/main/INSTALLATION.md).
+
+# Citing GeoCAT-datafiles
+
+If you use this software, please cite it as described at the [Citation](
+https://github.com/NCAR/geocat-datafiles/blob/main/CITATION.md) page.


### PR DESCRIPTION
We are starting to generate DOIs for each GeoCAT-comp version via the Zenodo minting service. Texts regarding citation are updated to reflect this change.