### PR TITLE
Add download retries

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -8,7 +8,8 @@ from ._version import __version__
 POOCH = pooch.create(
     path=pooch.os_cache('geocat'),
     base_url='https://github.com/NCAR/GeoCAT-datafiles/raw/main/',
-    registry={'registry.txt': None})
+    registry={'registry.txt': None},
+    retry_if_failed=10)
 
 def _update_registry(p):
     """


### PR DESCRIPTION
Turns on an option in Pooch to retry downloads if they fail.  

Needed for geocat-examples in particular.

Closes #65