### PR TITLE
NSF NCAR branding and update docs links in the README

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -13,20 +13,20 @@ the following text:
 
 **Visualization & Analysis Systems Technologies. (2020).
 Geoscience Community Analysis Toolkit: GeoCAT-datafiles [Software].
-Boulder, CO: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6684782.**
+Boulder, CO: NSF NCAR Computational and Information Systems Lab. doi:10.5281/zenodo.6684782.**
 
 Instead, if you would like to cite a specific version of GeoCAT-datafiles, use the following text:
 
 **Visualization & Analysis Systems Technologies. (\<Year\>).
 Geoscience Community Analysis Toolkit: GeoCAT-datafiles (v\<version\>) [Software].
-Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:\<DOI\>.**
+Boulder, CO, USA: NSF NCAR Computational and Information Systems Lab. doi:\<DOI\>.**
 
 In the above citation text, update the year, GeoCAT-datafiles version, and DOI as appropriate. For
 example:
 
 **Visualization & Analysis Systems Technologies. (2022).
 Geoscience Community Analysis Toolkit: GeoCAT-datafiles (v2022.03.0) [Software].
-Boulder, CO, USA: UCAR/NCAR - Computational and Informational System Lab. doi:10.5281/zenodo.6684830.**
+Boulder, CO, USA: NSF NCAR Computational and Information Systems Lab. doi:10.5281/zenodo.6684830.**
 
 Please find DOIs for all the GeoCAT-datafiles versions [here](
 https://zenodo.org/search?page=1&size=20&q=conceptrecid:%226684782%22&sort=-version&all_versions=True).

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ This repository contains data files used by
 to test or demonstrate GeoCAT functionality. The repo has several directories for data files
 in different formats (e.g. netCDF) and provides a convenience function to access those files with ease:
 
-    `geocat.datafiles.get(fname)`
+`geocat.datafiles.get(fname)`
     
-where `fname` should be given as a string of the format "`folder_name/filename`", e.g. "`netcdf_files/any_file.nc`".
+where `fname` should be given as a string of the format `"folder_name/file_name"`, e.g. `"netcdf_files/any_file.nc"`.
 
-The `geocat.datafiles.get(fname)` function fetches the file by reading from local storage, if any, or
+This function fetches the file by reading from local storage, if any, or
 downloading from the GeoCAT-datafiles repository with the help of
 [Pooch](https://www.fatiando.org/pooch).
 

--- a/README.md
+++ b/README.md
@@ -6,31 +6,25 @@
 
 # GeoCAT-datafiles
 
-This repository contains the many data files that are used by 
-[GeoCAT-examples](https://github.com/NCAR/geocat-examples) and possibly other GeoCAT components 
-to test or demonstrate GeoCAT functionality. The repo has several directories for different data files types 
-(such as NetCDF) as well as provide a convenience function to access those files with ease:
+This repository contains data files used by 
+[GeoCAT-examples](https://github.com/NCAR/geocat-examples) and other GeoCAT components
+to test or demonstrate GeoCAT functionality. The repo has several directories for data files
+in different formats (e.g. netCDF) and provides a convenience function to access those files with ease:
 
     `geocat.datafiles.get(fname)`
     
 where `fname` should be given as a string of the format "`folder_name/filename`", e.g. "`netcdf_files/any_file.nc`".
 
-`geocat.datafiles.get(fname)` function fetches the file by simply reading from the local storage, if any, or 
-downloading from the GeoCAT-datafiles repository, if not in the local storage, with the help of 
-[PyPi's Pooch framework](https://pypi.org/project/pooch/)  
+The `geocat.datafiles.get(fname)` function fetches the file by reading from local storage, if any, or
+downloading from the GeoCAT-datafiles repository with the help of
+[Pooch](https://www.fatiando.org/pooch).
 
 
 # Documentation
 
-[GeoCAT Homepage](https://geocat.ucar.edu/)
+[Installation Instructions](INSTALLATION.md)
 
-[GeoCAT Contributor's Guide](https://geocat.ucar.edu/pages/contributing.html)
-
-
-# Installation instructions
-
-Please see our documentation for 
-[installation instructions](https://github.com/NCAR/geocat-datafiles/blob/main/INSTALLATION.md).
+[Contributing Guidelines](CONTRIBUTING.md)
 
 # Citing GeoCAT-datafiles
 


### PR DESCRIPTION
Updates our citation information to properly acknowledge NSF.  This appears to be the only place we need to update this repo.

Also, updates the README to links to the appropriate docs and cleans up the formatting a bit.

Closes #64.