### PR TITLE
Pin Third Party Github Actions

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -46,7 +46,7 @@ jobs:
         run: |
           python -m twine check dist/*
       - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
           user: __token__
           password: ${{ secrets.PYPI_GEOCAT_DATAFILES }}


### PR DESCRIPTION
Pins third party Github actions to a commit hash instead of version tag

Closes #108 