### PR TITLE
Switch to PyPI trusted publishing

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -46,7 +46,5 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
         with:
-          user: __token__
-          password: ${{ secrets.PYPI_GEOCAT_DATAFILES }}
           skip_existing: true
           verbose: true


### PR DESCRIPTION
Last thing to tidy up in switching over to PyPI trusted publishing.

Closes #69.